### PR TITLE
Code necessary for migrating DATE fields to INT(11) fields

### DIFF
--- a/Aurora/DataManager/DataManagerBase.cs
+++ b/Aurora/DataManager/DataManagerBase.cs
@@ -309,6 +309,7 @@ namespace Aurora.DataManager
         public abstract bool Insert(string table, Dictionary<string, object> row);
         public abstract bool Insert(string table, object[] values, string updateKey, object updateValue);
         public abstract bool InsertMultiple(string table, List<object[]> values);
+        public abstract bool InsertSelect(string tableA, string[] fieldsA, string tableB, string[] valuesB);
 
         #endregion
 
@@ -330,7 +331,6 @@ namespace Aurora.DataManager
         public abstract void CloseDatabase();
 
         public abstract IGenericData Copy();
-        public abstract string FormatDateTimeString(int time);
         public abstract string ConCat(string[] toConcat);
 
         #endregion

--- a/Aurora/DataManager/Migration/Migrators/Auth/AuthMigrator_5.cs
+++ b/Aurora/DataManager/Migration/Migrators/Auth/AuthMigrator_5.cs
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Contributors, http://aurora-sim.org/
+ * See CONTRIBUTORS.TXT for a full list of copyright holders.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Aurora-Sim Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using Aurora.Framework;
+using C5;
+
+namespace Aurora.DataManager.Migration.Migrators
+{
+    public class AuthMigrator_5 : Migrator
+    {
+        public AuthMigrator_5()
+        {
+            Version = new Version(0, 0, 5);
+            MigrationName = "Auth";
+
+            schema = new List<Rec<string, ColumnDefinition[], IndexDefinition[]>>();
+
+            //
+            // Change summery:
+            //
+            //   Make the password hash much longer to accommodate other types of passwords)
+            //
+
+            AddSchema("auth", ColDefs(
+                ColDef("UUID", ColumnTypes.Char36),
+                ColDef("passwordHash", ColumnTypes.String1024),
+                ColDef("passwordSalt", ColumnTypes.String1024),
+                ColDef("accountType", ColumnTypes.Char32)
+            ), IndexDefs(
+                IndexDef(new string[2]{ "UUID", "accountType" }, IndexType.Primary),
+                IndexDef(new string[1]{ "passwordHash" }, IndexType.Index)
+            ));
+
+            AddSchema("tokens", ColDefs(
+                ColDef("UUID", ColumnTypes.Char36),
+                ColDef("token", ColumnTypes.String255),
+                ColDef("validity", ColumnTypes.Date)
+            ), IndexDefs(
+                IndexDef(new string[2] { "UUID", "token" }, IndexType.Primary)
+            ));
+
+            AddSchema("tokens2", ColDefs(
+                ColDef("UUID", ColumnTypes.Char36),
+                ColDef("token", ColumnTypes.String255),
+                ColDef("validity", ColumnTypes.Integer11)
+            ), IndexDefs(
+                IndexDef(new string[2] { "UUID", "token" }, IndexType.Primary)
+            ));
+        }
+
+        protected override void DoCreateDefaults(IDataConnector genericData)
+        {
+            EnsureAllTablesInSchemaExist(genericData);
+        }
+
+        protected override bool DoValidate(IDataConnector genericData)
+        {
+            return TestThatAllTablesValidate(genericData);
+        }
+
+        protected override void DoMigrate(IDataConnector genericData)
+        {
+            DoCreateDefaults(genericData);
+        }
+
+        protected override void DoPrepareRestorePoint(IDataConnector genericData)
+        {
+            CopyAllTablesToTempVersions(genericData);
+        }
+
+        public override void FinishedMigration(IDataConnector genericData)
+        {
+            genericData.InsertSelect("tokens2", new string[3]{
+                "UUID",
+                "token",
+                "validity"
+            }, "tokens", new string[3]{
+                "UUID",
+                "token",
+                (genericData is Aurora.DataManager.SQLite.SQLiteLoader) ? "strftime('%s', valdity)" : "UNIX_TIMESTAMP(validity)"
+            });
+            genericData.DropTable("tokens");
+            genericData.RenameTable("tokens2", "tokens");
+        }
+    }
+}

--- a/Aurora/Framework/Services/IApplicationPlugin.cs
+++ b/Aurora/Framework/Services/IApplicationPlugin.cs
@@ -300,7 +300,7 @@ namespace Aurora.Framework
 
         private static string preparedKey(string key)
         {
-            return key.Replace("`", "").Replace("(", "_").Replace(")", "").Replace(" ", "_").Replace("-", "minus").Replace("+", "add").Replace("/", "divide").Replace("*", "multiply");
+            return key.Replace("`", "").Replace("(", "_").Replace(")", "").Replace(" ", "_").Replace("-", "minus").Replace("+", "add").Replace("/", "divide").Replace("*", "multiply").Replace("'", "").Replace(",", "");
         }
 
         public string ToSQL(char prepared, out Dictionary<string, object> ps, ref uint j)

--- a/Aurora/Framework/Services/IApplicationPlugin.cs
+++ b/Aurora/Framework/Services/IApplicationPlugin.cs
@@ -170,6 +170,16 @@ namespace Aurora.Framework
         /// <returns></returns>
         bool Insert(string table, object[] values, string updateKey, object updateValue);
 
+        /// <summary>
+        /// Inserts rows selected from another table.
+        /// </summary>
+        /// <param name="tableA"></param>
+        /// <param name="fieldsA"></param>
+        /// <param name="tableB"></param>
+        /// <param name="valuesB"></param>
+        /// <returns></returns>
+        bool InsertSelect(string tableA, string[] fieldsA, string tableB, string[] valuesB);
+
         #endregion
 
         #region REPLACE INTO
@@ -204,14 +214,6 @@ namespace Aurora.Framework
         bool Delete(string table, QueryFilter queryFilter);
 
         #endregion
-
-        /// <summary>
-        ///   Formats a datetime string for the given time
-        ///   0 returns now()
-        /// </summary>
-        /// <param name = "time"></param>
-        /// <returns></returns>
-        string FormatDateTimeString(int time);
 
         /// <summary>
         ///   Connects to the database and then performs migrations

--- a/Aurora/Services/DataService/Connectors/Database/Auth/LocalAuthConnector.cs
+++ b/Aurora/Services/DataService/Connectors/Database/Auth/LocalAuthConnector.cs
@@ -129,7 +129,7 @@ namespace Aurora.Services.DataService
             Dictionary<string, object> row = new Dictionary<string, object>(3);
             row["UUID"] = principalID;
             row["token"] = token;
-            row["validity"] = GD.FormatDateTimeString(lifetime);
+            row["validity"] = Utils.DateTimeToUnixTime(DateTime.Now) + (lifetime * 60);
 
             return GD.Replace(m_tokensrealm, row);
         }
@@ -141,13 +141,14 @@ namespace Aurora.Services.DataService
                 DoExpire();
             }
 
+            uint now = Utils.DateTimeToUnixTime(DateTime.Now);
             Dictionary<string, object> values = new Dictionary<string, object>(1);
-            values["validity"] = GD.FormatDateTimeString(lifetime);
+            values["validity"] = now + (lifetime * 60) ;
 
             QueryFilter filter = new QueryFilter();
             filter.andFilters["UUID"] = principalID;
             filter.andFilters["token"] = token;
-            filter.andFilters["validity"] = GD.FormatDateTimeString(0);
+            filter.andLessThanEqFilters["validity"] = (int)now;
 
             return GD.Update(m_tokensrealm, values, null, filter, null, null);
         }

--- a/prebuild.xml
+++ b/prebuild.xml
@@ -404,6 +404,7 @@
       <Reference name="System.Xml"/>
       
       <Reference name="Aurora.Framework"/>
+      <Reference name="Aurora.DataManager.SQLite"/>
 
       <Reference name="C5" path="../../bin/"/>
       <Reference name="Nini" path="../../bin/"/>


### PR DESCRIPTION
I've been getting some issues with the token creation recently- seemingly related to MySQL's strict-mode operation. On further investigation, I noticed that the tokens table was using minute-based operations when the validity field was DATE, which doesn't include minutes.

The new migrator for the Auth table does an insert-select operation from the old table to the new table, performing a manual typecast on the fields.

IGenericData gets a new InsertSelect method, and the format date string method is now removed.
