### PR TITLE
Change how calculations of what neighbouring regions can be seen

### DIFF
--- a/Aurora/Modules/World/EntityTransfer/EntityTransferModule.cs
+++ b/Aurora/Modules/World/EntityTransfer/EntityTransferModule.cs
@@ -148,10 +148,10 @@ namespace Aurora.Modules.EntityTransfer
             
             if (reg == null)
             {
-                List<GridRegion> regions = sp.Scene.GridService.GetRegionRange(sp.Scene.RegionInfo.ScopeID, x - sp.Scene.GridService.GetMaxRegionSize(),
-                    x + sp.Scene.GridService.GetMaxRegionSize(),
-                    y - sp.Scene.GridService.GetMaxRegionSize(),
-                    y + sp.Scene.GridService.GetMaxRegionSize());
+                List<GridRegion> regions = sp.Scene.GridService.GetRegionRange(sp.Scene.RegionInfo.ScopeID, x - (sp.Scene.GridService.GetRegionViewSize() * sp.Scene.RegionInfo.RegionSizeX),
+                    x + (sp.Scene.GridService.GetRegionViewSize() * sp.Scene.RegionInfo.RegionSizeX),
+                    y - (sp.Scene.GridService.GetRegionViewSize() * sp.Scene.RegionInfo.RegionSizeY),
+                    y + (sp.Scene.GridService.GetRegionViewSize() * sp.Scene.RegionInfo.RegionSizeY));
                 foreach (GridRegion r in regions)
                 {
                     if (r.RegionLocX <= x && r.RegionLocX + r.RegionSizeX > x &&

--- a/OpenSim/Services/GridService/GridService.cs
+++ b/OpenSim/Services/GridService/GridService.cs
@@ -50,7 +50,6 @@ namespace OpenSim.Services.GridService
         protected IRegionData m_Database;
         private bool m_DeleteOnUnregister = true;
         protected bool m_DisableRegistrations;
-        protected int m_RegionViewSize = 256;
         protected bool m_UseSessionID = true;
         protected IConfigSource m_config;
         protected int m_maxRegionSize = 8192;
@@ -83,8 +82,7 @@ namespace OpenSim.Services.GridService
                 m_DisableRegistrations = gridConfig.GetBoolean("DisableRegistrations", m_DisableRegistrations);
                 m_AllowNewRegistrations = gridConfig.GetBoolean("AllowNewRegistrations", m_AllowNewRegistrations);
                 m_maxRegionSize = gridConfig.GetInt("MaxRegionSize", m_maxRegionSize);
-                m_RegionViewSize = gridConfig.GetInt("RegionViewSize", m_RegionViewSize / Constants.RegionSize) *
-                                   Constants.RegionSize;
+                m_cachedRegionViewSize = gridConfig.GetInt("RegionSightSize", m_cachedRegionViewSize);
                 m_UseSessionID = !gridConfig.GetBoolean("DisableSessionID", !m_UseSessionID);
                 m_AllowDuplicateNames = gridConfig.GetBoolean("AllowDuplicateNames", m_AllowDuplicateNames);
             }
@@ -163,14 +161,14 @@ namespace OpenSim.Services.GridService
         public virtual int GetRegionViewSize()
         {
             if (m_cachedRegionViewSize != 0)
-                return m_cachedMaxRegionSize;
+                return m_cachedRegionViewSize;
             object remoteValue = DoRemote();
-            if (remoteValue != null || m_doRemoteOnly)
+            if (remoteValue != null && m_doRemoteOnly)
             {
-                m_cachedMaxRegionSize = (int)remoteValue;
-                return (int)remoteValue;
+                m_cachedRegionViewSize = (int)remoteValue;
             }
-            return m_RegionViewSize;
+            else m_cachedRegionViewSize = 1;
+            return m_cachedRegionViewSize;
         }
 
         public virtual IGridService InnerService

--- a/OpenSim/Services/MessagingService/MessagingModules/AgentProcessing/AgentProcessing.cs
+++ b/OpenSim/Services/MessagingService/MessagingModules/AgentProcessing/AgentProcessing.cs
@@ -432,9 +432,9 @@ namespace OpenSim.Services.MessagingService
                                    {
                                        int count = 0;
                                        IGridService gridService = m_registry.RequestModuleInterface<IGridService>();
-                                       int xMin = (caps.Region.RegionLocX) + (int)(position.X) - (gridService != null ? gridService.GetMaxRegionSize() : 8192);
+                                       int xMin = (caps.Region.RegionLocX) + (int)(position.X) - ((gridService != null ? gridService.GetRegionViewSize() : 1) * caps.Region.RegionSizeX);
                                        int xMax = (caps.Region.RegionLocX) + (int) (position.X) + 256;
-                                       int yMin = (caps.Region.RegionLocY) + (int)(position.Y) - (gridService != null ? gridService.GetMaxRegionSize() : 8192);
+                                       int yMin = (caps.Region.RegionLocY) + (int)(position.Y) - ((gridService != null ? gridService.GetRegionViewSize() : 1) * caps.Region.RegionSizeY);
                                        int yMax = (caps.Region.RegionLocY) + (int) (position.Y) + 256;
 
                                        //Ask the grid service about the range


### PR DESCRIPTION
...egionSize (which by default it over 8000 meters) to calculate how far away to see, used existing config entry RegionSightSize \* the current region size.
