### PR TITLE
Work around for memory leak when changing prim map over and over

### DIFF
--- a/Aurora/AuroraDotNetEngine/APIs/LSL_Api.cs
+++ b/Aurora/AuroraDotNetEngine/APIs/LSL_Api.cs
@@ -7991,7 +7991,7 @@ namespace Aurora.ScriptEngine.AuroraDotNetEngine.APIs
             shapeBlock.PathCurve = part.Shape.PathCurve;
             part.Shape.SetSculptProperties((byte)type, sculptId);
             part.Shape.SculptEntry = true;
-            part.UpdateShape(shapeBlock);
+            part.UpdateShape(shapeBlock, false);
         }
 
         public void llSetPrimitiveParams(LSL_List rules)

--- a/Aurora/Framework/SceneInfo/ISceneChildEntity.cs
+++ b/Aurora/Framework/SceneInfo/ISceneChildEntity.cs
@@ -484,5 +484,6 @@ namespace Aurora.Framework
         void ScriptSetTemporaryStatus(bool tempOnRez);
 
         uint InventorySerial { get; set; }
+		void UpdateShape(ObjectShapePacket.ObjectDataBlock shapeBlock, bool b);
     }
 }

--- a/Aurora/Framework/SceneInfo/LandData.cs
+++ b/Aurora/Framework/SceneInfo/LandData.cs
@@ -728,6 +728,8 @@ namespace Aurora.Framework
             Private = map["Private"].AsBoolean();
             GenericData = map.ContainsKey("GenericDataMap") && map["GenericDataMap"].Type == OSDType.Map ? 
                 (OSDMap)map["GenericDataMap"] : new OSDMap();
+				
+			if ((IsGroupOwned) && (GroupID != OwnerID)) OwnerID = GroupID;
         }
 
         public override void FromKVP(Dictionary<string, object> KVP)

--- a/Aurora/Framework/Utils/SchedulerItem.cs
+++ b/Aurora/Framework/Utils/SchedulerItem.cs
@@ -26,7 +26,9 @@
  */
 
 using System;
+using System.Reflection;
 using OpenMetaverse;
+using OpenMetaverse.StructuredData;
 
 namespace Aurora.Framework
 {
@@ -47,7 +49,7 @@ namespace Aurora.Framework
         Megaannum = 13
     }
 
-    public class SchedulerItem
+    public class SchedulerItem: IDataTransferable
     {
         public SchedulerItem()
         {
@@ -137,6 +139,45 @@ namespace Aurora.Framework
         public RepeatType RunEveryType { get; set; }
 
         public DateTime StartTime { get; set; }
+
+        public override OSDMap ToOSD()
+        {
+            OSDMap returnvalue = new OSDMap()
+                                     {
+                                         {"id", id},
+                                         {"HistoryLastID", HistoryLastID},
+                                         {"TimeToRun",TimeToRun},
+                                         {"Enabled",Enabled},
+                                         {"HisotryKeep",HisotryKeep},
+                                         {"FireParams",FireParams},
+                                         {"FireFunction",FireFunction},
+                                         {"HistoryReciept",HistoryReciept},
+                                         {"RunOnce",RunOnce},
+                                         {"RunEvery",RunEvery},
+                                         {"CreateTime",CreateTime},
+                                         {"RunEveryType", (int)RunEveryType},
+                                         {"StartTime",StartTime}
+                                     };
+            
+            return returnvalue;
+        }
+
+        public override void FromOSD(OSDMap map)
+        {
+            id = map["id"].AsString();
+            HistoryLastID = map["HistoryLastID"].AsString();
+            TimeToRun = map["TimeToRun"].AsDate();
+            Enabled = map["Enabled"].AsBoolean();
+            HisotryKeep = map["HisotryKeep"].AsBoolean();
+            FireParams = map["FireParams"].AsString();
+            FireFunction = map["FireFunction"].AsString();
+            HistoryReciept = map["HistoryReciept"].AsBoolean();
+            RunOnce = map["RunOnce"].AsBoolean();
+            RunEvery = map["RunEvery"].AsInteger();
+            CreateTime = map["CreateTime"].AsDate();
+            RunEveryType = (RepeatType)map["RunEveryType"].AsInteger();
+            StartTime = map["StartTime"].AsDate();
+        }
     }
 
     public class SchedulerHistory

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -2459,8 +2459,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// <returns>A Linked Child Prim objects position in world</returns>
         public Vector3 GetWorldPosition()
         {
-            Quaternion parentRot = ParentGroup.RootPart.RotationOffset;
-            return (GroupPosition + OffsetPosition*parentRot);
+            return IsRoot ? GroupPosition : GroupPosition + OffsetPosition * ParentGroup.RootPart.RotationOffset;
         }
 
         /// <summary>

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -3749,20 +3749,33 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name = "shapeBlock"></param>
         public void UpdateShape(ObjectShapePacket.ObjectDataBlock shapeBlock)
         {
+            UpdateShape(shapeBlock, true);
+        }
+
+        /// <summary>
+        ///   Having this function because I found when scripts updated the shape.. over and over, it would fill up the memory
+        ///   Having the extra paramater updatePhysics can prevent physics updates on the changes
+        ///   The onlyplace this effects is if a script changes the shape
+        ///   If the LocklessQueue gets updated this can be removed
+        /// </summary>
+        /// <param name = "shapeBlock"></param>
+        /// <param name="UpdatePhysics"></param>
+        public void UpdateShape(ObjectShapePacket.ObjectDataBlock shapeBlock, bool UpdatePhysics)
+        {
             IOpenRegionSettingsModule module = ParentGroup.Scene.RequestModuleInterface<IOpenRegionSettingsModule>();
             if (module != null)
             {
-                if (shapeBlock.ProfileHollow > (module.MaximumHollowSize*500) &&
+                if (shapeBlock.ProfileHollow > (module.MaximumHollowSize * 500) &&
                     module.MaximumHollowSize != -1)
-                    //This is so that it works correctly, since the packet sends (N * 500)
+                //This is so that it works correctly, since the packet sends (N * 500)
                 {
-                    shapeBlock.ProfileHollow = (ushort) (module.MaximumHollowSize*500);
+                    shapeBlock.ProfileHollow = (ushort)(module.MaximumHollowSize * 500);
                 }
-                if (shapeBlock.PathScaleY > (200 - (module.MinimumHoleSize*100)) &&
+                if (shapeBlock.PathScaleY > (200 - (module.MinimumHoleSize * 100)) &&
                     module.MinimumHoleSize != -1 && shapeBlock.PathCurve == 32)
-                    //This is how the packet is set up... so this is how we check for it...
+                //This is how the packet is set up... so this is how we check for it...
                 {
-                    shapeBlock.PathScaleY = Convert.ToByte((200 - (module.MinimumHoleSize*100)));
+                    shapeBlock.PathScaleY = Convert.ToByte((200 - (module.MinimumHoleSize * 100)));
                 }
             }
 
@@ -3788,7 +3801,7 @@ namespace OpenSim.Region.Framework.Scenes
 
             Shape = m_shape;
 
-            if (PhysActor != null)
+            if ((UpdatePhysics) && (PhysActor != null))
             {
                 PhysActor.Shape = m_shape;
                 m_parentGroup.Scene.PhysicsScene.AddPhysicsActorTaint(PhysActor);


### PR DESCRIPTION
I found that with a script changing a sculpty over and over it would cause the region memory to raise rapidly. To combat this I have disabled the recalculation of the prims physics when a script changes the sculpty map.

I know this is not a fix, its a work around... but I really don't understand why the memory is growing so much.. 
