### PR TITLE
Region owner fix on startup of regions

### DIFF
--- a/Aurora/Services/DataService/Connectors/Database/Grid/LocalGridConnector.cs
+++ b/Aurora/Services/DataService/Connectors/Database/Grid/LocalGridConnector.cs
@@ -414,6 +414,14 @@ namespace Aurora.Services.DataService
         {
             if (region.EstateOwner == UUID.Zero)
             {
+                IEstateConnector EstateConnector = Aurora.DataManager.DataManager.RequestPlugin<IEstateConnector>();
+                EstateSettings ES = EstateConnector.GetEstateSettings(region.RegionID);
+                if (ES != null)
+                    region.EstateOwner = ES.EstateOwner;
+            }
+
+            if (region.EstateOwner == UUID.Zero)
+            {
                 MainConsole.Instance.Error("[LocalGridConnector] Attempt to store region with owner of UUID.Zero detected:" + (new System.Diagnostics.StackTrace()).GetFrame(1).ToString());
             }
 


### PR DESCRIPTION
On RegisterRegion on startup the EstateSettings are empty because the sim does not have that information in the RegionInfo table in the db.

The only place where the owner information per region is, is in the estate table. This fix gets the EstateSettings and owner from the estate tables iso the regionInfo sended on registerregion.
