### PR TITLE
Add missing permissions to default Shape asset

### DIFF
--- a/OpenSim/Services/InventoryService/InventoryService.cs
+++ b/OpenSim/Services/InventoryService/InventoryService.cs
@@ -292,7 +292,12 @@ namespace OpenSim.Services.InventoryService
                     asset.ID = m_AssetService.Store(asset);
                     defaultShape.AssetID = asset.ID;
                     defaultShape.Folder = bodypartFolder.ID;
-                    defaultShape.CreatorId = UUID.Zero.ToString();
+                    defaultShape.CreatorId = m_LibraryService.LibraryOwner.ToString();
+                    defaultShape.Owner = principalID;
+                    defaultShape.BasePermissions = (uint)PermissionMask.All;
+                    defaultShape.CurrentPermissions = (uint)PermissionMask.All;
+                    defaultShape.EveryOnePermissions = (uint)PermissionMask.None;
+                    defaultShape.NextPermissions = (uint)PermissionMask.All;
                     AddItem(defaultShape, false);
                 }
 


### PR DESCRIPTION
this needed for v3 viewers to actually wear the default shape.
other default assets already have right permissions.
