### PR TITLE
adding passwordless AbuseReport retrieval

### DIFF
--- a/Aurora/Framework/DatabaseInterfaces/IAbuseReportsConnector.cs
+++ b/Aurora/Framework/DatabaseInterfaces/IAbuseReportsConnector.cs
@@ -41,6 +41,13 @@ namespace Aurora.Framework
         AbuseReport GetAbuseReport(int Number, string Password);
 
         /// <summary>
+        /// Gets the abuse report associated with the number without authentication
+        /// </summary>
+        /// <param name="Number"></param>
+        /// <returns></returns>
+        AbuseReport GetAbuseReport(int Number);
+
+        /// <summary>
         ///   Adds a new abuse report to the database
         /// </summary>
         /// <param name = "report"></param>

--- a/Aurora/Framework/Services/IAbuseReports.cs
+++ b/Aurora/Framework/Services/IAbuseReports.cs
@@ -152,6 +152,13 @@ namespace OpenSim.Services.Interfaces
         AbuseReport GetAbuseReport(int Number, string Password);
 
         /// <summary>
+        /// Gets the abuse report associated with the number without authentication
+        /// </summary>
+        /// <param name="Number"></param>
+        /// <returns></returns>
+        AbuseReport GetAbuseReport(int Number);
+
+        /// <summary>
         ///   Adds a new abuse report to the database
         /// </summary>
         /// <param name = "report"></param>

--- a/Aurora/Services/DataService/Connectors/Local/LocalAbuseReportsConnector.cs
+++ b/Aurora/Services/DataService/Connectors/Local/LocalAbuseReportsConnector.cs
@@ -81,11 +81,16 @@ namespace Aurora.Services.DataService
         /// <returns></returns>
         public AbuseReport GetAbuseReport(int Number, string Password)
         {
-            if (!CheckPassword(Password))
-            {
-                return null;
-            }
+            return (!CheckPassword(Password)) ? null :GetAbuseReport(Number);
+        }
 
+        /// <summary>
+        /// Gets the abuse report associated with the number without authentication
+        /// </summary>
+        /// <param name="Number"></param>
+        /// <returns></returns>
+        public AbuseReport GetAbuseReport(int Number)
+        {
             QueryFilter filter = new QueryFilter();
             filter.andFilters["Number"] = Number;
             List<string> Reports = GD.Query(new string[] { "*" }, m_abuseReportsTable, filter, null, null, null);

--- a/OpenSim/Services/AbuseReportsService/AbuseReportsService.cs
+++ b/OpenSim/Services/AbuseReportsService/AbuseReportsService.cs
@@ -64,10 +64,25 @@ namespace OpenSim.Services.AbuseReports
                 return (AbuseReport)remoteValue;
 
             IAbuseReportsConnector conn = DataManager.RequestPlugin<IAbuseReportsConnector>();
-            if (conn != null)
-                return conn.GetAbuseReport(Number, Password);
-            else
-                return null;
+            return (conn != null) ? conn.GetAbuseReport(Number, Password) : null;
+        }
+
+        /// <summary>
+        /// Cannot be reflected on purpose, so it can only be used locally.
+        /// Gets the abuse report associated with the number without authentication.
+        /// </summary>
+        /// <param name="Number"></param>
+        /// <returns></returns>
+        public AbuseReport GetAbuseReport(int Number)
+        {
+            object remoteValue = DoRemote(Number);
+            if (remoteValue != null || m_doRemoteOnly)
+            {
+                return (AbuseReport)remoteValue;
+            }
+
+            IAbuseReportsConnector conn = DataManager.RequestPlugin<IAbuseReportsConnector>();
+            return (conn != null) ? conn.GetAbuseReport(Number) : null;
         }
 
         [CanBeReflected(ThreatLevel = OpenSim.Services.Interfaces.ThreatLevel.Full)]
@@ -82,7 +97,6 @@ namespace OpenSim.Services.AbuseReports
                 conn.UpdateAbuseReport(report, Password);
         }
 
-        [CanBeReflected(ThreatLevel = OpenSim.Services.Interfaces.ThreatLevel.Full)]
         public List<AbuseReport> GetAbuseReports(int start, int count, bool active)
         {
             object remoteValue = DoRemote(start, count, active);


### PR DESCRIPTION
If I recall the way the reflective stuff works, if a method isn't explicitly set to be reflective then it's not available to remote regions ?
