### PR TITLE
Foldername changes and removal

### DIFF
--- a/OpenSim/Services/InventoryService/InventoryService.cs
+++ b/OpenSim/Services/InventoryService/InventoryService.cs
@@ -248,24 +248,17 @@ namespace OpenSim.Services.InventoryService
 
             if (!Array.Exists(sysFolders, delegate(InventoryFolderBase f)
             {
-                if (f.Type == (short)AssetType.Mesh) return true;
-                return false;
-            }))
-                CreateFolder(principalID, rootFolder.ID, (int)AssetType.Mesh, "Mesh");
-
-            if (!Array.Exists(sysFolders, delegate(InventoryFolderBase f)
-            {
                 if (f.Type == 50/*(short)AssetType.Inbox*/) return true;
                 return false;
             }))
-                CreateFolder(principalID, rootFolder.ID, 50/*(int)AssetType.Inbox*/, "Inbox");
+                CreateFolder(principalID, rootFolder.ID, 50/*(int)AssetType.Inbox*/, "Received Items");
 
             if (!Array.Exists(sysFolders, delegate(InventoryFolderBase f)
             {
                 if (f.Type == 51/*(short)AssetType.Outbox*/) return true;
                 return false;
             }))
-                CreateFolder(principalID, rootFolder.ID, 51/*(int)AssetType.Outbox*/, "Outbox");
+                CreateFolder(principalID, rootFolder.ID, 51/*(int)AssetType.Outbox*/, "Merchant Outbox");
 
             if (createDefaultItems && m_LibraryService != null)
             {


### PR DESCRIPTION
It seemed the folder Mesh was twice being created in a new person's Inventory.

Also renamed the Inbox / Outbox to the Received Items / Merchant Outbox
