### PR TITLE
Change reusecontext to false only if we caught a socket or an IO exception, so we might be able to use some script services as WebUI login

### DIFF
--- a/Aurora/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/Aurora/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -493,6 +493,7 @@ namespace Aurora.Framework.Servers.HttpServer
                     }
                     catch (IOException e)
                     {
+                        response.ReuseContext = false; // This has to be here to prevent a Linux/Mono crash
                         MainConsole.Instance.Warn("[BASE HTTP SERVER]: XmlRpcRequest issue: " + e);
                     }
                     //This makes timeouts VERY bad if enabled

--- a/Aurora/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/Aurora/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -483,12 +483,12 @@ namespace Aurora.Framework.Servers.HttpServer
                     //
                     try
                     {
-                        response.ReuseContext = false;
+                        response.ReuseContext = true;
                         response.Send();
                     }
                     catch (SocketException e)
                     {
-                        // This has to be here to prevent a Linux/Mono crash
+                        response.ReuseContext = false; // This has to be here to prevent a Linux/Mono crash
                         MainConsole.Instance.WarnFormat("[BASE HTTP SERVER]: XmlRpcRequest issue {0}.\nNOTE: this may be spurious on Linux.", e);
                     }
                     catch (IOException e)


### PR DESCRIPTION
It might be safe to set it to true since that HTTP IN support is oly for scripts, but still we need to deny its use if we caught an exception (for Linux users)
