### PR TITLE
Added method for building string from OSDMap

### DIFF
--- a/Aurora/Framework/Utils/Util.cs
+++ b/Aurora/Framework/Utils/Util.cs
@@ -123,6 +123,24 @@ namespace Aurora.Framework
             return builder.ToString();
         }
 
+        //wab - Added for debugging ease
+        public static string ConvertToString(OSDMap values, string lineStart = "\t")
+        {
+            StringBuilder builder = new StringBuilder ();
+            String[] keys = new String[values.Count];
+            values.Keys.CopyTo (keys, 0);
+            foreach (String key in keys) {
+                 Object val = values [key];
+                 if (val == null)
+                     builder.AppendFormat("{0}{1}=null\n", lineStart, key);
+                 else if (val is OSDMap)
+                     builder.AppendFormat("{0}{1}=...\n{2}", lineStart, key, ConvertToString((OSDMap)val, "\t\t"));
+                 else
+                     builder.AppendFormat("{0}{1}={2}\n", lineStart, key, val.ToString());
+            }
+            return builder.ToString();
+        }
+
         public static List<string> ConvertToList(string listAsString)
         {
             //Do both , and " " so that it removes any annoying spaces in the string added by users


### PR DESCRIPTION
The new additional ConvertToString method takes an OSDMap, and optionally a line prefix string, and returns a multi-line string formatting of the OSDMap suitable for use in debug messages.  If the values in the OSDMap are themselves OSDMap instances then these are formatted in the same way.  If the value is null then just the string null is printed for the value.  In all other cases the ToString method is called on the value to get the string used in the result.  This method is especially useful when dumping XMLRPC requests and responses, or RemoteCall params.
