### PR TITLE
Support for ~, %username% and %homedrive% in backup paths

### DIFF
--- a/Aurora/Framework/Utils/PathHelpers.cs
+++ b/Aurora/Framework/Utils/PathHelpers.cs
@@ -1,0 +1,154 @@
+﻿/*
+ * Copyright (c) Contributors, http://aurora-sim.org/
+ * See CONTRIBUTORS.TXT for a full list of copyright holders.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Aurora-Sim Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Aurora.Framework
+{
+    public class PathHelpers
+    {
+        const string usernameVar = "%username%";
+        public static string PathUsername(string Path) //supports using %username% in place of username
+        {
+            if (Path.IndexOf(usernameVar, StringComparison.CurrentCultureIgnoreCase) == -1) //does not contain username var
+            {
+                return Path;
+            }
+            else //contains username var
+            {
+                string userName = Environment.UserName; //check system for current username
+                return Regex.Replace(Path, usernameVar, userName, RegexOptions.IgnoreCase); //return Path with the system username
+            }
+        }
+
+        const string HomedriveVar = "%homedrive%";
+        public static string PathHomeDrive(string Path) //supports for %homedrive%, gives the drive letter on Windows
+        {
+            if (Path.IndexOf(HomedriveVar, StringComparison.CurrentCultureIgnoreCase) == -1) //does not contain username var
+            {
+                return Path;
+            }
+            else
+            {
+                if (Util.IsLinux)
+                {
+                    return Path;
+                }
+                else
+                {
+                    string DriveLetter = Environment.GetEnvironmentVariable("HOMEDRIVE");
+
+                    return Regex.Replace(Path, HomedriveVar, DriveLetter, RegexOptions.IgnoreCase);
+                }
+            }
+        }
+
+        public static string PathTilde(string Path) //supports ~ for home dir at beginning of Path
+        {
+            if (Path.IndexOf("~", StringComparison.CurrentCultureIgnoreCase) == -1) //does not contain ~
+            {
+                return Path;
+            }
+            else
+            {
+                if (Path[0].ToString() == "~")
+                {
+                    string homePath = "";
+
+                    if (Util.IsLinux)
+                    {
+                        homePath = Environment.GetEnvironmentVariable("HOME");
+                    }
+                    else
+                    {
+                        homePath = Environment.GetEnvironmentVariable("userprofile");
+                    }
+
+                    Path = Path.Substring(1);
+                    return homePath + Path;
+                }
+                else
+                {
+                    return Path;
+                }
+            }
+        }
+
+        public static string CorrectSlash(string Path) //become someone is obsessed with perfection....
+        {
+            string slash;
+
+            if (Util.IsLinux)
+            {
+                slash = "/"; //forward slash
+            }
+            else
+            {
+                slash = "\\"; //back slash
+            }
+
+            Path = Path.Replace("/", slash);
+            Path = Path.Replace("\\", slash);
+
+            return Path;
+        }
+
+        public static string ForceEndSlash(string Path)
+        {
+            string LastCharacter = Path.Last().ToString();
+
+            if (LastCharacter == "/" || LastCharacter == "\\")
+            {
+                return Path;
+            }
+            else
+            {
+                return Path + "/";
+            }
+        }
+
+        public static string ComputeFullPath(string Path, bool forceSlash = true) //single function that calls the functions that help compute a full url Path
+        {
+            Path = PathHomeDrive(
+                PathUsername(
+                    PathTilde(Path)
+                )
+            );
+
+            if (forceSlash)
+            {
+                Path = ForceEndSlash(Path);
+            }
+
+            return CorrectSlash(Path);
+        }
+    }
+}

--- a/Aurora/Framework/Utils/Util.cs
+++ b/Aurora/Framework/Utils/Util.cs
@@ -484,6 +484,15 @@ namespace Aurora.Framework
             return true;
         }
 
+        public static bool IsLinux
+        {
+            get
+            {
+                int p = (int)Environment.OSVersion.Platform;
+                return (p == 4) || (p == 6) || (p == 128);
+            }
+        }
+
         public static int UnixTimeSinceEpoch()
         {
             return ToUnixTime(DateTime.UtcNow);

--- a/Aurora/Modules/World/Startup/SimulationData/FileBasedSimulationData.cs
+++ b/Aurora/Modules/World/Startup/SimulationData/FileBasedSimulationData.cs
@@ -310,9 +310,9 @@ namespace Aurora.Modules.Startup.FileBasedSimulationData
                 m_saveChanges = config.GetBoolean("SaveChanges", m_saveChanges);
                 m_timeBetweenSaves = config.GetInt("TimeBetweenSaves", m_timeBetweenSaves);
                 m_keepOldSave = config.GetBoolean("SavePreviousBackup", m_keepOldSave);
-                m_oldSaveDirectory = config.GetString("PreviousBackupDirectory", m_oldSaveDirectory);
-                m_loadDirectory = config.GetString("LoadBackupDirectory", m_loadDirectory);
-                m_saveDirectory = config.GetString("SaveBackupDirectory", m_saveDirectory);
+                m_oldSaveDirectory = PathHelpers.ComputeFullPath(config.GetString("PreviousBackupDirectory", m_oldSaveDirectory));
+                m_loadDirectory = PathHelpers.ComputeFullPath(config.GetString("LoadBackupDirectory", m_loadDirectory));
+                m_saveDirectory = PathHelpers.ComputeFullPath(config.GetString("SaveBackupDirectory", m_saveDirectory));
                 m_saveBackupChanges = config.GetBoolean("SaveTimedPreviousBackup", m_keepOldSave);
                 m_timeBetweenBackupSaves = config.GetInt("TimeBetweenBackupSaves", m_timeBetweenBackupSaves);
             }

--- a/Documentation/CONTRIBUTORS.txt
+++ b/Documentation/CONTRIBUTORS.txt
@@ -14,6 +14,7 @@ djphil
 SignpostMarv
 JAllard
 Fly-Man-
+Kevin Whitman (@Keverw)
 
 ------------------ OpenSim ------------------
 

--- a/bin/Configuration/Data/FileBased.ini.example
+++ b/bin/Configuration/Data/FileBased.ini.example
@@ -7,6 +7,8 @@
 	;; rather than from a normal database. This is much faster than a normal database and can be used to
 	;; automatically save backups of regions as well. This is the default option in Aurora
 	;;
+	;; In directory paths you can use ~ for home directory, %username% to put your user name in the path. On Windows, you can use %homedrive% in place of your drive letter(Like if you stored your backups already on an external hard drive letter, X for example vs. C main drive).
+	;;
 	
 	;;
 	;; Configuration Settings

--- a/bin/Configuration/Data/FileBased.ini.example
+++ b/bin/Configuration/Data/FileBased.ini.example
@@ -1,74 +1,74 @@
 [SimulationDataStore]
     DatabaseLoaderName = "FileBasedDatabase"
-	
+    
 [FileBasedSimulationData]
     ;;
     ;; This plugin loads the region information (such as terrain and objects) from an Aurora Backup file 
-	;; rather than from a normal database. This is much faster than a normal database and can be used to
-	;; automatically save backups of regions as well. This is the default option in Aurora
-	;;
-	;; In directory paths you can use ~ for home directory, %username% to put your user name in the path. On Windows, you can use %homedrive% in place of your drive letter(Like if you stored your backups already on an external hard drive letter, X for example vs. C main drive).
-	;;
-	
-	;;
-	;; Configuration Settings
-	;;
-	
-	;; Directory to load the backups from
-	;; Normally is the bin directory, but you can change this to anywhere on your hard drive
-	;; Default is ""
-	LoadBackupDirectory = "/"
-	
-	;; Directory to save new backups into
-	;; Normally this is the bin directory, but this can be changed to any place on your HD
-	;; Default is ""
-	SaveBackupDirectory = "/"
-	
-	;; Should we save any changes that occur in the sim? (This is useful for sandboxes as you can 
-	;;  decide not to persist any changes and just restart the sim to clear it)
-	;; Default is true
-	SaveChanges = true
-	
-	;; This module saves periodic backups of the region so that if it crashes, you do not lose anything
-	;; This allows you to change the amount of time (in minutes) between the auto saves
-	;; Default is 5 (minutes)
-	TimeBetweenSaves = 5
-	
-	;; This will make a copy of the last backup that was made of the sim and put it in the "Backup" directory
-	;; This makes sure that you have a good backup if something does go wrong (the backups are time stamped so
-	;;  you can tell when it was taken)
-	;; Default is true
-	SavePreviousBackup = true
-	
-	;; If you enabled SavePreviousBackup, this is the directory (in the bin folder) where the old saves
-	;; will be put
-	;; Default is "Backups"
-	PreviousBackupDirectory = "Backups/"
-	
-	;; The normal file name to load from for each region is "<Region Name Here>.abackup"
-	;; If you wish to change that, you can add this so that it becomes
-	;; "<Region Name Here><This config option setting>.abackup"
-	;; which allows for a bit of flexibility when loading.
-	;; Default is ""
+    ;; rather than from a normal database. This is much faster than a normal database and can be used to
+    ;; automatically save backups of regions as well. This is the default option in Aurora
+    ;;
+    ;; In directory paths you can use ~ for home directory, %username% to put your user name in the path. On Windows, you can use %homedrive% in place of your drive letter(Like if you stored your backups already on an external hard drive letter, X for example vs. C main drive).
+    ;;
+    
+    ;;
+    ;; Configuration Settings
+    ;;
+    
+    ;; Directory to load the backups from
+    ;; Normally is the bin directory, but you can change this to anywhere on your hard drive
+    ;; Default is ""
+    LoadBackupDirectory = "/"
+    
+    ;; Directory to save new backups into
+    ;; Normally this is the bin directory, but this can be changed to any place on your HD
+    ;; Default is ""
+    SaveBackupDirectory = "/"
+    
+    ;; Should we save any changes that occur in the sim? (This is useful for sandboxes as you can 
+    ;;  decide not to persist any changes and just restart the sim to clear it)
+    ;; Default is true
+    SaveChanges = true
+    
+    ;; This module saves periodic backups of the region so that if it crashes, you do not lose anything
+    ;; This allows you to change the amount of time (in minutes) between the auto saves
+    ;; Default is 5 (minutes)
+    TimeBetweenSaves = 5
+    
+    ;; This will make a copy of the last backup that was made of the sim and put it in the "Backup" directory
+    ;; This makes sure that you have a good backup if something does go wrong (the backups are time stamped so
+    ;;  you can tell when it was taken)
+    ;; Default is true
+    SavePreviousBackup = true
+    
+    ;; If you enabled SavePreviousBackup, this is the directory (in the bin folder) where the old saves
+    ;; will be put
+    ;; Default is "Backups"
+    PreviousBackupDirectory = "Backups/"
+    
+    ;; The normal file name to load from for each region is "<Region Name Here>.abackup"
+    ;; If you wish to change that, you can add this so that it becomes
+    ;; "<Region Name Here><This config option setting>.abackup"
+    ;; which allows for a bit of flexibility when loading.
+    ;; Default is ""
     AppendedLoadFileName = "";
-	
-	;; The normal file name to save for each region is "<Region Name Here>.abackup"
-	;; If you wish to change that, you can add this so that it becomes
-	;; "<Region Name Here><This config option setting>.abackup"
-	;; which allows for a bit of flexibility when saving the backups.
-	;; Default is ""
+    
+    ;; The normal file name to save for each region is "<Region Name Here>.abackup"
+    ;; If you wish to change that, you can add this so that it becomes
+    ;; "<Region Name Here><This config option setting>.abackup"
+    ;; which allows for a bit of flexibility when saving the backups.
+    ;; Default is ""
     AppendedSaveFileName = "";
-	
-	;; This will make a backup of the sim every X minutes and put it in the "Backup" directory
-	;; This makes sure that you have a good backup if something does go wrong (the backups are time stamped so
-	;;  you can tell when it was taken)
-	;; Default is true
-	SaveTimedPreviousBackup = true
-	
-	;; This module saves periodic backups of the region into the PreviousBackupDirectory 
-	;; so that you have time stamped backups of your region indefinitely
-	;; This allows you to change the amount of time (in minutes) between the auto saves
-	;; Default is 1440 (minutes) (1 day)
-	TimeBetweenBackupSaves = 1440
-	
-	
+    
+    ;; This will make a backup of the sim every X minutes and put it in the "Backup" directory
+    ;; This makes sure that you have a good backup if something does go wrong (the backups are time stamped so
+    ;;  you can tell when it was taken)
+    ;; Default is true
+    SaveTimedPreviousBackup = true
+    
+    ;; This module saves periodic backups of the region into the PreviousBackupDirectory 
+    ;; so that you have time stamped backups of your region indefinitely
+    ;; This allows you to change the amount of time (in minutes) between the auto saves
+    ;; Default is 1440 (minutes) (1 day)
+    TimeBetweenBackupSaves = 1440
+    
+    


### PR DESCRIPTION
Added support for ~, %username% and %homedrive% in backup paths, for the LoadBackupDirectory, SaveBackupDirectory and PreviousBackupDirectory paths. 

Made a PathHelpers class, so if there is any other paths, or future paths that need this, it's reusable and plus it looks neater.

Hope I did good on my first commit :)
