### PR TITLE
 Add more Char lengths like CHAR(37) for DataManager

### DIFF
--- a/Aurora/DataManager/Migration/Migrator.cs
+++ b/Aurora/DataManager/Migration/Migrator.cs
@@ -120,8 +120,26 @@ namespace Aurora.DataManager.Migration
                 case ColumnTypes.Char32:
                     type = ColumnTypeDef.Char32;
                     break;
+                case ColumnTypes.Char33:
+                    type = ColumnTypeDef.Char33;
+                    break;
+                case ColumnTypes.Char34:
+                    type = ColumnTypeDef.Char34;
+                    break;
+                case ColumnTypes.Char35:
+                    type = ColumnTypeDef.Char35;
+                    break;
                 case ColumnTypes.Char36:
                     type = ColumnTypeDef.Char36;
+                    break;
+                case ColumnTypes.Char37:
+                    type = ColumnTypeDef.Char37;
+                    break;
+                case ColumnTypes.Char38:
+                    type = ColumnTypeDef.Char38;
+                    break;
+                case ColumnTypes.Char39:
+                    type = ColumnTypeDef.Char39;
                     break;
                 case ColumnTypes.Char40:
                     type = ColumnTypeDef.Char40;

--- a/Aurora/DataManagerPlugins/MySQL/MySQLDataManager.cs
+++ b/Aurora/DataManagerPlugins/MySQL/MySQLDataManager.cs
@@ -804,8 +804,20 @@ namespace Aurora.DataManager.MySQL
                     return "INT(30) UNSIGNED";
                 case ColumnTypes.Char40:
                     return "CHAR(40)";
+                case ColumnTypes.Char39:
+                    return "CHAR(39)";
+                case ColumnTypes.Char38:
+                    return "CHAR(38)";
+                case ColumnTypes.Char37:
+                    return "CHAR(37)";
                 case ColumnTypes.Char36:
                     return "CHAR(36)";
+                case ColumnTypes.Char35:
+                    return "CHAR(35)";
+                case ColumnTypes.Char34:
+                    return "CHAR(34)";
+                case ColumnTypes.Char33:
+                    return "CHAR(33)";
                 case ColumnTypes.Char32:
                     return "CHAR(32)";
                 case ColumnTypes.Char5:

--- a/Aurora/DataManagerPlugins/SQLite/SQLiteDataManager.cs
+++ b/Aurora/DataManagerPlugins/SQLite/SQLiteDataManager.cs
@@ -970,8 +970,20 @@ namespace Aurora.DataManager.SQLite
                     return "INT(30) UNSIGNED";
                 case ColumnTypes.Char40:
                     return "CHAR(40)";
+                case ColumnTypes.Char39:
+                    return "CHAR(39)";
+                case ColumnTypes.Char38:
+                    return "CHAR(38)";
+                case ColumnTypes.Char37:
+                    return "CHAR(37)";
                 case ColumnTypes.Char36:
                     return "CHAR(36)";
+                case ColumnTypes.Char35:
+                    return "CHAR(35)";
+                case ColumnTypes.Char34:
+                    return "CHAR(34)";
+                case ColumnTypes.Char33:
+                    return "CHAR(33)";
                 case ColumnTypes.Char32:
                     return "CHAR(32)";
                 case ColumnTypes.Char5:

--- a/Aurora/Framework/Utilities/IDataConnector.cs
+++ b/Aurora/Framework/Utilities/IDataConnector.cs
@@ -186,7 +186,13 @@ namespace Aurora.Framework.Utilities
         Blob,
         LongBlob,
         Char40,
+        Char39,
+        Char38,
+        Char37,
         Char36,
+        Char35,
+        Char34,
+        Char33,
         Char32,
         Char5,
         Char1,
@@ -252,7 +258,13 @@ namespace Aurora.Framework.Utilities
 
         public static readonly ColumnTypeDef Blob = new ColumnTypeDef(ColumnType.Blob);
         public static readonly ColumnTypeDef Char32 = new ColumnTypeDef(ColumnType.Char, 32);
+        public static readonly ColumnTypeDef Char33 = new ColumnTypeDef(ColumnType.Char, 33);
+        public static readonly ColumnTypeDef Char34 = new ColumnTypeDef(ColumnType.Char, 34);
+        public static readonly ColumnTypeDef Char35 = new ColumnTypeDef(ColumnType.Char, 35);
         public static readonly ColumnTypeDef Char36 = new ColumnTypeDef(ColumnType.Char, 36);
+        public static readonly ColumnTypeDef Char37 = new ColumnTypeDef(ColumnType.Char, 37);
+        public static readonly ColumnTypeDef Char38 = new ColumnTypeDef(ColumnType.Char, 38);
+        public static readonly ColumnTypeDef Char39 = new ColumnTypeDef(ColumnType.Char, 39);
         public static readonly ColumnTypeDef Char40 = new ColumnTypeDef(ColumnType.Char, 40);
         public static readonly ColumnTypeDef Char5 = new ColumnTypeDef(ColumnType.Char, 5);
         public static readonly ColumnTypeDef Char1 = new ColumnTypeDef(ColumnType.Char, 1);


### PR DESCRIPTION
 Add more Char lengths like CHAR(37) for DataManager to work around the CHAR(36) MySql.Data.dll limitation/bug that it assumes that anything CHAR(36) has to be an UUID and therefore will conduct format checks. This is specially made for those that need to create fixed length database rows for performance increases.
