### PR TITLE
Fixed problem where status code would always be returned as 200 to http_response regardless of actual status code

### DIFF
--- a/Aurora/Modules/Scripting/HttpRequest/ScriptsHttpRequests.cs
+++ b/Aurora/Modules/Scripting/HttpRequest/ScriptsHttpRequests.cs
@@ -560,8 +560,7 @@ namespace Aurora.Modules.Scripting
                 if (response != null)
                     response.Close();
             }
-
-            Status = (int) HttpStatusCode.OK;
+            
             _finished = true;
         }
 


### PR DESCRIPTION
Removed `Status = (int) HttpStatusCode.OK;` as every request in http_response(key request_id, integer status, list metadata, string body) would return 200, regardless as the actual status code. So if the page was not found, you got 200 instead of 404. If you hit a page in maintenance mode you get 200 instead of 503.

The `Status` code variable was always being over written to 200 before returning what the actual server returned when doing a llHTTPRequest. Removed that line of code and everything seems to work as expected.
