### PR TITLE
Fix Offline IM E-Mails Not Being Sent

### DIFF
--- a/Aurora/Framework/Utilities/WebUtils.cs
+++ b/Aurora/Framework/Utilities/WebUtils.cs
@@ -267,13 +267,12 @@ namespace Aurora.Framework.Utilities
                 {
                     HttpWebResponse webResponse = (HttpWebResponse)we.Response;
                     if (webResponse.StatusCode == HttpStatusCode.BadRequest)
-                        MainConsole.Instance.WarnFormat("[WebUtils]: bad request to {0}, data {1}", url,
-                                                        buffer != null ? OSDParser.SerializeJsonString(buffer) : "");
+                        //AR: Removed JSON Data filling console on connecting to down regions
+                        MainConsole.Instance.WarnFormat("[WebUtils]: WebException bad request to {0}", url);
                     else
-                        MainConsole.Instance.Warn(string.Format("[WebUtils]: {0} to {1}, data {2}, response {3}",
-                                                        webResponse.StatusCode, url,
-                                                        buffer != null ? OSDParser.SerializeJsonString(buffer) : "",
-                                                        webResponse.StatusDescription));
+                        //AR: Removed JSON Data filling console on connecting to down regions
+                        MainConsole.Instance.Warn(string.Format("[WebUtils]: WebException {0} to {1}",
+                                                        webResponse.StatusCode, url));
                     return new byte[0];
                 }
                 if (request != null)
@@ -319,8 +318,8 @@ namespace Aurora.Framework.Utilities
 
             if (MainConsole.Instance != null)
                 using (MemoryStream stream = new MemoryStream(buffer))
-                    MainConsole.Instance.WarnFormat("[WebUtils]: request failed: {0} to {1}, data {2}", errorMessage,
-                                                    url, buffer != null ? OSDParser.SerializeJsonString(OSDParser.DeserializeJson(stream)) : "");
+                    //AR: Removed JSON Data filling console on connecting to down regions
+                    MainConsole.Instance.WarnFormat("[WebUtils]: request failed: {0} to {1}", errorMessage, url);
             return new byte[0];
         }
 

--- a/Aurora/Modules/Avatar/AuroraChat/AuroraOfflineMessagesModule.cs
+++ b/Aurora/Modules/Avatar/AuroraChat/AuroraOfflineMessagesModule.cs
@@ -230,7 +230,7 @@ namespace Aurora.Modules.Chat
                         Framework.Utilities.DataManager.RequestPlugin<IProfileConnector>().GetUserProfile(im.ToAgentID);
                     if (profile != null && profile.IMViaEmail)
                     {
-                        UserAccount account = m_Scene.UserAccountService.GetUserAccount(null, im.ToAgentID.ToString());
+                        UserAccount account = m_Scene.UserAccountService.GetUserAccount(null, im.ToAgentID);
                         if (account != null && !string.IsNullOrEmpty(account.Email))
                         {
                             emailModule.SendEmail(UUID.Zero, account.Email,

--- a/Aurora/Modules/Scripting/EmailModules/EmailModule.cs
+++ b/Aurora/Modules/Scripting/EmailModules/EmailModule.cs
@@ -125,11 +125,13 @@ namespace Aurora.Modules.Scripting
                     {
                         //Creation EmailMessage
 
-                        string fromEmailAddress = "@" + m_HostName;
-                        if (scene != null)
+                        string fromEmailAddress;
+
+                        if (scene != null && objectID != UUID.Zero)
                             fromEmailAddress = objectID.ToString() + "@" + m_HostName;
                         else
-                            fromEmailAddress = "noreply@" + m_HostName;
+                            fromEmailAddress = "no-reply@" + m_HostName;
+
                         EmailMessage emailMessage = new EmailMessage
                                                         {
                                                             FromAddress =
@@ -142,9 +144,17 @@ namespace Aurora.Modules.Scripting
                         //Text
                         emailMessage.BodyText = body;
                         if (scene != null)
-                            emailMessage.BodyText = "Object-Name: " + LastObjectName +
-                                                    "\nRegion: " + LastObjectRegionName + "\nLocal-Position: " +
-                                                    LastObjectPosition + "\n\n" + emailMessage.BodyText;
+                        {
+                            // If Object Null Dont Include Object Info Headers (Offline IMs)
+                            if(objectID != UUID.Zero)
+                                emailMessage.BodyText = "Object-Name: " + LastObjectName +
+                                                        "\nRegion: " + LastObjectRegionName + "\nLocal-Position: " +
+                                                        LastObjectPosition + "\n\n";
+
+                            emailMessage.BodyText += emailMessage.BodyText;
+                        }
+
+                        
 
                         //Config SMTP Server
                         //Set SMTP SERVER config


### PR DESCRIPTION
Users account object was not returned in offline IM module because UUID
was passed as a string causing the find account method to treat it as a
User Name. Also prevent E-Mail module including headers for prim
information when used for IMs.

Also a commit to remove the full JSON decode from printing to console when grid server keeps trying to connect to offline regions.
