### PR TITLE
Prevent bots being added to currency table

### DIFF
--- a/Aurora/Modules/Avatar/Currency/Simple.CurrencyConnector.cs
+++ b/Aurora/Modules/Avatar/Currency/Simple.CurrencyConnector.cs
@@ -370,7 +370,14 @@ namespace Simple.Currency
 
         private void UserCurrencyCreate(UUID agentId)
         {
-            m_gd.Insert(_REALM, new object[] {agentId.ToString(), 0, 0, 0, 0, 0});
+            // Check if this agent has a user account, if not assume its a bot and exit
+            UserAccount account = m_registry.RequestModuleInterface<IUserAccountService>()
+                          .GetUserAccount(new List<UUID> { UUID.Zero }, agentId);
+
+            if (account != null)
+            {
+                m_gd.Insert(_REALM, new object[] {agentId.ToString(), 0, 0, 0, 0, 0});
+            }
         }
 
         private void GroupCurrencyCreate(UUID groupID)


### PR DESCRIPTION
Fix Bug #1261. Prevent bots being added to currency table. With bots having random UUID every time they restart, this soon would get out of hand with trash data. I have tested what happens when a bot is paid after this patch and the user looses the money paid but there are no errors shown on console. Seems ok to me.
