### PR TITLE
Fix Bug 1334 Prim Name Filter Broken For Listens

### DIFF
--- a/Aurora/Modules/Scripting/WorldComm/WorldCommModule.cs
+++ b/Aurora/Modules/Scripting/WorldComm/WorldCommModule.cs
@@ -647,10 +647,10 @@ namespace Aurora.Modules.Scripting
                                     where li.IsActive()
                                     where itemID.Equals(UUID.Zero) || li.GetItemID().Equals(itemID)
                                     where li.GetName().Length <= 0 || li.GetName().Equals(name)
-                                    where li.GetName().Length <= 0 || ((li.RegexBitfield & OS_LISTEN_REGEX_NAME) != OS_LISTEN_REGEX_NAME && !li.GetName().Equals(name)) ||
-                                            ((li.RegexBitfield & OS_LISTEN_REGEX_NAME) == OS_LISTEN_REGEX_NAME && !Regex.IsMatch(name, li.GetName()))
-                                    where li.GetName().Length <= 0 || ((li.RegexBitfield & OS_LISTEN_REGEX_MESSAGE) != OS_LISTEN_REGEX_MESSAGE && !li.GetMessage().Equals(msg)) ||
-                                            ((li.RegexBitfield & OS_LISTEN_REGEX_MESSAGE) == OS_LISTEN_REGEX_MESSAGE && !Regex.IsMatch(msg, li.GetMessage()))
+                                    where li.GetName().Length <= 0 || ((li.RegexBitfield & OS_LISTEN_REGEX_NAME) != OS_LISTEN_REGEX_NAME && li.GetName().Equals(name)) ||
+                                                                      ((li.RegexBitfield & OS_LISTEN_REGEX_NAME) == OS_LISTEN_REGEX_NAME && Regex.IsMatch(name, li.GetName()))
+                                    where li.GetMessage().Length <= 0 || ((li.RegexBitfield & OS_LISTEN_REGEX_MESSAGE) != OS_LISTEN_REGEX_MESSAGE && li.GetMessage().Equals(msg)) ||
+                                                                         ((li.RegexBitfield & OS_LISTEN_REGEX_MESSAGE) == OS_LISTEN_REGEX_MESSAGE && Regex.IsMatch(msg, li.GetMessage()))
                                     where li.GetID().Equals(UUID.Zero) || li.GetID().Equals(id)
                                     where li.GetMessage().Length <= 0 || li.GetMessage().Equals(msg)
                                     select li);


### PR DESCRIPTION
In OS the terms here are to Exclude listeners from being matched, now in Aurora since this part was changed to Linq, they are used to Include listeners. The where statements were not reversed. Also in one place Name length was checked instead of message length.

Not entirely sure what Regex is supposed to do, i know this is what was blocking the name filter on listens and it works now. But does the regex still do its part correctly? Have i reversed the 'where' statements correctly?
