### PR TITLE
Take Scripted Prim Fix

### DIFF
--- a/Aurora/Modules/World/Entities/ObjectDelete/AsyncSceneObjectGroupDeleter.cs
+++ b/Aurora/Modules/World/Entities/ObjectDelete/AsyncSceneObjectGroupDeleter.cs
@@ -180,12 +180,6 @@ namespace Aurora.Modules.Entities.ObjectDelete
             {
                 if (m_removeFromSimQueue.TryDequeue(out x))
                 {
-                    if (x.permissionToDelete)
-                    {
-                        IBackupModule backup = m_scene.RequestModuleInterface<IBackupModule>();
-                        if (backup != null)
-                            backup.DeleteSceneObjects(x.objectGroups.ToArray(), true, true);
-                    }
                     MainConsole.Instance.DebugFormat(
                         "[SCENE]: Sending object to user's inventory, {0} item(s) remaining.",
                         m_removeFromSimQueue.Count);
@@ -204,6 +198,14 @@ namespace Aurora.Modules.Entities.ObjectDelete
                             MainConsole.Instance.ErrorFormat(
                                 "[ASYNC DELETER]: Exception background sending object: {0}{1}", e.Message, e.StackTrace);
                         }
+                    }
+
+                    //AR: Moved Delete To After Object Taken To Inventory. Prevents script variables not being updated before taken to inventory
+                    if (x.permissionToDelete)
+                    {
+                        IBackupModule backup = m_scene.RequestModuleInterface<IBackupModule>();
+                        if (backup != null)
+                            backup.DeleteSceneObjects(x.objectGroups.ToArray(), true, true);
                     }
                     return true;
                 }


### PR DESCRIPTION
http://mantis.aurora-sim.org/view.php?id=1335

Hi Rev. This is a fix for the script state save problem i was having. The scripts state was not updated because the object was removed from world before being taken to inventory. This stopped the variables being updated. The actual state save was working fine with protobuf or xml. Im not sure why you didnt see the same effect unless you where taking a copy and leaving the object in world. Any ideas?
