### PR TITLE
Fix Bug 1320 Multi Region Bug With Group IM's

### DIFF
--- a/Aurora/Services/GenericServices/InstantMessagingService/InstantMessagingService.cs
+++ b/Aurora/Services/GenericServices/InstantMessagingService/InstantMessagingService.cs
@@ -74,9 +74,14 @@ namespace Aurora.Services
                 {
                     foreach (GridInstantMessage im in messages)
                     {
+                        Framework.PresenceInfo.IScenePresence UserPresence;
+
                         foreach (IScene scene in manager.Scenes)
                         {
-                            if (scene.GetScenePresence(im.ToAgentID) != null)
+                            UserPresence = scene.GetScenePresence(im.ToAgentID);
+
+                            //AR: Do not fire for child agents or group messages are sent for every region
+                            if (UserPresence != null && UserPresence.IsChildAgent == false)
                             {
                                 IMessageTransferModule messageTransfer = scene.RequestModuleInterface<IMessageTransferModule>();
                                 if (messageTransfer != null)


### PR DESCRIPTION
When a sim has more than one region, group IM's are sent multiple times.
This fix prevents sending received IMs to child agents.

http://mantis.aurora-sim.org/view.php?id=1320
