### PR TITLE
Fix rez perms

### DIFF
--- a/Aurora/Framework/Modules/IInventoryAccessModule.cs
+++ b/Aurora/Framework/Modules/IInventoryAccessModule.cs
@@ -66,7 +66,7 @@ namespace Aurora.Framework.Modules
         /// <param name="itemID"></param>
         /// <param name="assetID"></param>
         /// <returns></returns>
-        ISceneEntity CreateObjectFromInventory(IClientAPI remoteClient, UUID itemID, UUID assetID);
+        ISceneEntity CreateObjectFromInventory(IClientAPI remoteClient, UUID itemID, UUID assetID, InventoryItemBase item);
 
         /// <summary>
         ///     Rez an object from inventory and add it to the scene

--- a/Aurora/Modules/Avatar/Attachments/AttachmentsModule.cs
+++ b/Aurora/Modules/Avatar/Attachments/AttachmentsModule.cs
@@ -390,7 +390,7 @@ namespace Aurora.Modules.Attachments
                 ISceneEntity objatt = assetID == UUID.Zero
                                           ? invAccess.CreateObjectFromInventory(remoteClient,
                                                                                 itemID, out item)
-                                          : invAccess.CreateObjectFromInventory(remoteClient, itemID, assetID);
+                                          : invAccess.CreateObjectFromInventory(remoteClient, itemID, assetID, null);
 
                 if (objatt != null)
                 {

--- a/Aurora/Modules/World/InventoryAccess/InventoryAccessModule.cs
+++ b/Aurora/Modules/World/InventoryAccess/InventoryAccessModule.cs
@@ -611,13 +611,13 @@ namespace Aurora.Modules.InventoryAccess
                 //
                 itemId = item.ID;
             }
-            return CreateObjectFromInventory(remoteClient, itemId, item.AssetID, out doc);
+            return CreateObjectFromInventory(remoteClient, itemId, item.AssetID, out doc, item);
         }
 
-        public virtual ISceneEntity CreateObjectFromInventory(IClientAPI remoteClient, UUID itemID, UUID assetID)
+        public virtual ISceneEntity CreateObjectFromInventory(IClientAPI remoteClient, UUID itemID, UUID assetID, InventoryItemBase item)
         {
             XmlDocument doc;
-            return CreateObjectFromInventory(remoteClient, itemID, assetID, out doc);
+            return CreateObjectFromInventory(remoteClient, itemID, assetID, out doc, item);
         }
 
         protected virtual ISceneEntity CreateObjectFromInventory(InventoryItemBase item, IClientAPI remoteClient,
@@ -640,11 +640,11 @@ namespace Aurora.Modules.InventoryAccess
                 //
                 itemId = item.ID;
             }
-            return CreateObjectFromInventory(remoteClient, itemId, item.AssetID, out doc);
+            return CreateObjectFromInventory(remoteClient, itemId, item.AssetID, out doc, item);
         }
 
         protected virtual ISceneEntity CreateObjectFromInventory(IClientAPI remoteClient, UUID itemID, UUID assetID,
-                                                                 out XmlDocument doc)
+                                                                 out XmlDocument doc, InventoryItemBase item)
         {
             byte[] rezAsset = m_scene.AssetService.GetData(assetID.ToString());
 
@@ -683,6 +683,14 @@ namespace Aurora.Modules.InventoryAccess
                 group.IsDeleted = false;
                 foreach (ISceneChildEntity part in group.ChildrenEntities())
                 {
+                    //AR: Could be changed by user in inventory, so restore from inventory not asset on rez
+                    if (item != null)
+                    {
+                        part.EveryoneMask = item.EveryOnePermissions;
+                        part.GroupMask = item.GroupPermissions;
+                        part.NextOwnerMask = item.NextPermissions;
+                    }
+
                     part.IsLoading = false;
                 }
                 return group;


### PR DESCRIPTION
If perms are changed on object while inside inventory, when its rezzed it will revert to original perms from last time it was set in world. This fix applies perms from inventory item to the object during rez.
